### PR TITLE
Media validation - Id is mandatory

### DIFF
--- a/src/OpenRealEstate.FakeData/FakeCommonListingHelpers.cs
+++ b/src/OpenRealEstate.FakeData/FakeCommonListingHelpers.cs
@@ -84,12 +84,14 @@ namespace OpenRealEstate.FakeData
             {
                 new Media
                 {
+                    Id = Guid.NewGuid().ToString(),
                     Url = "http://www.someWebSite.com.au/tmp/floorplan1.gif",
                     CreatedOn = new DateTime(2009, 1, 1, 12, 30, 0, DateTimeKind.Utc),
                     Order = 1
                 },
                 new Media
                 {
+                    Id = Guid.NewGuid().ToString(),
                     Url = "http://www.someWebSite.com.au/tmp/floorplan2.gif",
                     CreatedOn = new DateTime(2009, 1, 1, 12, 30, 0, DateTimeKind.Utc),
                     Order = 2
@@ -103,12 +105,14 @@ namespace OpenRealEstate.FakeData
             {
                 new Media
                 {
+                    Id = Guid.NewGuid().ToString(),
                     Url = "http://www.someWebSite.com.au/tmp/imageM.jpg",
                     CreatedOn = new DateTime(2009, 1, 1, 12, 30, 0, DateTimeKind.Utc),
                     Order = 1
                 },
                 new Media
                 {
+                    Id = Guid.NewGuid().ToString(),
                     Url = "http://www.someWebSite.com.au/tmp/imageA.jpg",
                     CreatedOn = new DateTime(2009, 1, 1, 12, 30, 0, DateTimeKind.Utc),
                     Order = 2
@@ -166,6 +170,7 @@ namespace OpenRealEstate.FakeData
             {
                 new Media
                 {
+                    Id = Guid.NewGuid().ToString(),
                     Url = "http://www.foo.tv/abcd.html",
                     Order = 1,
                 }

--- a/src/OpenRealEstate.FakeData/FakeListings.cs
+++ b/src/OpenRealEstate.FakeData/FakeListings.cs
@@ -382,6 +382,7 @@ namespace OpenRealEstate.FakeData
 
             return Builder<Media>.CreateListOfSize(listSize)
                 .All()
+                .With(x => x.Id, Guid.NewGuid().ToString())
                 .With(x => x.ContentType, contentType)
                 .With(x => x.CreatedOn, DateTime.UtcNow)
                 .With(x => x.Url = GetRandom.Url()) // Each one needs to be unique, not reusing the same value. Notice the equals (=) vs the comma (,) ways.


### PR DESCRIPTION
minimal change to validate `id` property from `Media`

see REAXML specs for more details:
https://partner.realestate.com.au/documentation/api/listings/elements/#media
http://reaxml.realestate.com.au/propertyList.dtd

```
<!-- 'media' is designed to consolidate images, objects, videoLink, externalLink. -->
<!ELEMENT media (attachment)* >

<!ELEMENT attachment    ( #PCDATA ) >
<!ATTLIST attachment      id          CDATA                               #REQUIRED >
<!ATTLIST attachment      usage       (statementOfInformation|agentPhoto) #REQUIRED >
<!ATTLIST attachment      url         CDATA                               #REQUIRED >
```